### PR TITLE
92 재입고 알림 api

### DIFF
--- a/src/main/java/com/example/shinsekai/common/entity/BaseResponseStatus.java
+++ b/src/main/java/com/example/shinsekai/common/entity/BaseResponseStatus.java
@@ -78,14 +78,16 @@ public enum BaseResponseStatus {
     NO_EXIST_PRODUCT(HttpStatus.NOT_FOUND, false, 3001, "존재하지 않는 상품입니다"),
     NO_EXIST_OPTION(HttpStatus.NOT_FOUND, false, 3002, "존재하지 않는 옵션입니다"),
     NO_EXIST_CATEGORY(HttpStatus.NOT_FOUND, false, 3003, "존재하지 않는 카테고리입니다"),
-    NO_EXIST_PRODUCT_CATEGORY(HttpStatus.NOT_FOUND, false, 30010, "존재하지 않는 상품 카테고리입니다"),
+    NO_EXIST_PRODUCT_CATEGORY(HttpStatus.NOT_FOUND, false, 3010, "존재하지 않는 상품 카테고리입니다"),
 
     DUPLICATED_PRODUCT(HttpStatus.CONFLICT, false, 3004, "이미 등록된 상품입니다"),
     DUPLICATED_OPTION(HttpStatus.CONFLICT, false, 3005, "이미 등록된 옵션입니다"),
     DUPLICATED_CATEGORY(HttpStatus.CONFLICT, false, 3006, "이미 등록된 카테고리입니다"),
+    DUPLICATED_RESTOCK_NOTIFICATION(HttpStatus.CONFLICT, false, 3008, "이미 재입고 알림 신청이 완료 되었습니다"),
+    INVALID_RESTOCK_NOTIFICATION_CONDITION(HttpStatus.BAD_REQUEST, false, 3010, "재입고 알림은 품절 상품에만 신청할 수 있습니다."),
 
-    NO_EXIST_OPTIONS_IN_PRODUCT(HttpStatus.NOT_FOUND, false, 3007, "해당 상품에 옵션이 존재하지 않습니다"),
-    NOT_ENOUGH_STOCK(HttpStatus.CONFLICT, false, 3008, "해당 상품에 재고가 충분하지 않습니다"),
+    NO_EXIST_OPTIONS_IN_PRODUCT(HttpStatus.NOT_FOUND, false, 3008, "해당 상품에 옵션이 존재하지 않습니다"),
+    NOT_ENOUGH_STOCK(HttpStatus.CONFLICT, false, 3009, "해당 상품에 재고가 충분하지 않습니다"),
 
     // Cart
     CART_PRODUCT_KIND_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, false, 3108, "장바구니에 담을 수 있는 상품 종류는 최대 20개까지입니다"),

--- a/src/main/java/com/example/shinsekai/common/entity/BaseResponseStatus.java
+++ b/src/main/java/com/example/shinsekai/common/entity/BaseResponseStatus.java
@@ -84,10 +84,10 @@ public enum BaseResponseStatus {
     DUPLICATED_OPTION(HttpStatus.CONFLICT, false, 3005, "이미 등록된 옵션입니다"),
     DUPLICATED_CATEGORY(HttpStatus.CONFLICT, false, 3006, "이미 등록된 카테고리입니다"),
     DUPLICATED_RESTOCK_NOTIFICATION(HttpStatus.CONFLICT, false, 3008, "이미 재입고 알림 신청이 완료 되었습니다"),
-    INVALID_RESTOCK_NOTIFICATION_CONDITION(HttpStatus.BAD_REQUEST, false, 3010, "재입고 알림은 품절 상품에만 신청할 수 있습니다."),
+    INVALID_RESTOCK_NOTIFICATION_CONDITION(HttpStatus.BAD_REQUEST, false, 3009, "재입고 알림은 품절 상품에만 신청할 수 있습니다."),
 
-    NO_EXIST_OPTIONS_IN_PRODUCT(HttpStatus.NOT_FOUND, false, 3008, "해당 상품에 옵션이 존재하지 않습니다"),
-    NOT_ENOUGH_STOCK(HttpStatus.CONFLICT, false, 3009, "해당 상품에 재고가 충분하지 않습니다"),
+    NO_EXIST_OPTIONS_IN_PRODUCT(HttpStatus.NOT_FOUND, false, 3010, "해당 상품에 옵션이 존재하지 않습니다"),
+    NOT_ENOUGH_STOCK(HttpStatus.CONFLICT, false, 3011, "해당 상품에 재고가 충분하지 않습니다"),
 
     // Cart
     CART_PRODUCT_KIND_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, false, 3108, "장바구니에 담을 수 있는 상품 종류는 최대 20개까지입니다"),

--- a/src/main/java/com/example/shinsekai/email/application/EmailService.java
+++ b/src/main/java/com/example/shinsekai/email/application/EmailService.java
@@ -9,4 +9,5 @@ public interface EmailService {
     void sendVerificationEmail(EmailVerificationRequestDto emailVerificationRequestDto);
     void verifyCode(VerificationCodeRequestDto verificationCodeRequestDto);
     void sendTempPassword(SendTempRequestDto sendTempRequestDto);
+    void sendRestockEmail(String toEmail, String productName);
 }

--- a/src/main/java/com/example/shinsekai/email/entity/EmailType.java
+++ b/src/main/java/com/example/shinsekai/email/entity/EmailType.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum EmailType {
     FIND_LOGIN_ID("아이디찾기"),
     SIGN_UP("회원가입"),
-    TEMP_PW("임시비밀번호");
+    TEMP_PW("임시비밀번호"),
+    RESTOCK_NOTIFY("재입고 알림");
 
     private final String mailType;
 

--- a/src/main/java/com/example/shinsekai/email/templete/RestockEmailBuilder.java
+++ b/src/main/java/com/example/shinsekai/email/templete/RestockEmailBuilder.java
@@ -1,0 +1,42 @@
+package com.example.shinsekai.email.templete;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestockEmailBuilder {
+    public String buildRestockNotifyEmail(String productName){
+        return """
+            <html lang="ko">
+                <body style="font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f4f4f4;">
+                    <div style="width: 100%%; max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); text-align: center;">
+                        <img src="https://www.starbucks.co.kr/common/img/common/logo.png" alt="스타벅스 로고" style="width: 120px; margin: 20px 0;" />
+                        
+                        <p style="font-size: 24px; font-weight: bold; color: #00704A;">[스타벅스 스토어] 상품 재입고 알림</p>
+                        
+                        <p style="font-size: 16px; color: #333333; margin: 20px 0;">
+                            안녕하세요!
+                        </p>
+                        
+                        <p>고객님께서 신청하신 상품 <strong>%s</strong> 이(가) 재입고되었습니다 🎉</p>
+                        <p>지금 바로 확인해보세요!</p>
+                        <br>
+                        
+                        <a href='https://spharos.shop' style='background-color:#2e8b57; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;'>상품 보러가기</a>
+                        
+                        <p style="font-size: 16px; color: #333333; margin: 20px 0;">
+                            ※ 이 메일은 알림 수신 신청에 따라 발송된 안내 메일입니다.
+                        </p>
+                        
+                        <a href="https://www.spharosacademy.com/" style="display: inline-block; background-color: #00704A; color: #ffffff; padding: 12px 20px; text-decoration: none; border-radius: 5px; font-size: 16px; margin-top: 20px;">
+                            스파로스 아카데미 홈페이지 방문
+                        </a>
+                        
+                        <p style="font-size: 12px; color: #888888; margin-top: 30px;">
+                            본 메일은 스파로스 아카데미 6기 1차 프로젝트를 위해 개발되었습니다. <br />
+                        </p>
+                    </div>
+                </body>
+            </html>
+            """.formatted(productName);
+    }
+}

--- a/src/main/java/com/example/shinsekai/notification/application/RestockNotificationService.java
+++ b/src/main/java/com/example/shinsekai/notification/application/RestockNotificationService.java
@@ -1,0 +1,10 @@
+package com.example.shinsekai.notification.application;
+
+import com.example.shinsekai.notification.dto.in.RestockNotificationRequestDto;
+
+public interface RestockNotificationService {
+
+    void register(String memberUuid,RestockNotificationRequestDto dto);
+
+    void notifyForRestockedOption(Long productOptionId);
+}

--- a/src/main/java/com/example/shinsekai/notification/application/RestockNotificationServiceImpl.java
+++ b/src/main/java/com/example/shinsekai/notification/application/RestockNotificationServiceImpl.java
@@ -1,0 +1,78 @@
+package com.example.shinsekai.notification.application;
+
+import com.example.shinsekai.common.entity.BaseResponseStatus;
+import com.example.shinsekai.common.exception.BaseException;
+import com.example.shinsekai.email.application.EmailService;
+import com.example.shinsekai.member.entity.Member;
+import com.example.shinsekai.member.infrastructure.MemberRepository;
+import com.example.shinsekai.notification.dto.in.RestockNotificationRequestDto;
+import com.example.shinsekai.notification.entity.RestockNotification;
+import com.example.shinsekai.notification.infrastructure.RestockNotificationRepository;
+import com.example.shinsekai.option.entity.OptionStatus;
+import com.example.shinsekai.option.entity.ProductOptionList;
+import com.example.shinsekai.option.infrastructure.ProductOptionListRepository;
+import com.example.shinsekai.product.entity.Product;
+import com.example.shinsekai.product.infrastructure.ProductRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RestockNotificationServiceImpl implements RestockNotificationService {
+
+    private final RestockNotificationRepository restockNotificationRepository;
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+    private final ProductOptionListRepository productOptionListRepository;
+
+    private final EmailService emailService;
+
+    @Override
+    @Transactional
+    public void register(String memberUuid, RestockNotificationRequestDto dto) {
+        ProductOptionList productOptionList = productOptionListRepository.findById(dto.getProductOptionId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_OPTIONS_IN_PRODUCT));
+        if (!productOptionList.getOptionStatus().equals(OptionStatus.OUT_OF_STOCK)) {
+            throw new BaseException(BaseResponseStatus.INVALID_RESTOCK_NOTIFICATION_CONDITION);
+        }
+
+        if (restockNotificationRepository.existsByMemberUuidAndProductOptionIdAndNotifiedFalse(
+                memberUuid, dto.getProductOptionId())) {
+            throw new BaseException(BaseResponseStatus.EXIST_NOTIFICATION_SETTING);
+        }
+
+        RestockNotification notification = RestockNotification.builder()
+                .memberUuid(memberUuid)
+                .productOptionId(dto.getProductOptionId())
+                .requestedAt(LocalDateTime.now())
+                .validUntil(LocalDateTime.now().plusDays(dto.getDurationDays()))
+                .build();
+
+        restockNotificationRepository.save(notification);
+    }
+
+    @Override
+    @Transactional
+    public void notifyForRestockedOption(Long productOptionId) {
+        List<RestockNotification> notifications = restockNotificationRepository
+                .findAllByProductOptionIdAndNotifiedFalseAndValidUntilAfter(productOptionId, LocalDateTime.now());
+
+        for (RestockNotification n : notifications) {
+            Member member = memberRepository.findByMemberUuid(n.getMemberUuid())
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_USER));
+
+            ProductOptionList option = productOptionListRepository.findById(productOptionId)
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_OPTION));
+
+            Product product = productRepository.findByProductCode(option.getProductCode())
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_PRODUCT));
+
+            emailService.sendRestockEmail(member.getEmail(), product.getProductName());
+            n.markAsNotified();
+        }
+    }
+}

--- a/src/main/java/com/example/shinsekai/notification/dto/in/RestockNotificationRequestDto.java
+++ b/src/main/java/com/example/shinsekai/notification/dto/in/RestockNotificationRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.shinsekai.notification.dto.in;
+
+import com.example.shinsekai.notification.vo.in.RestockNotificationRequestVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RestockNotificationRequestDto {
+    private Long productOptionId;
+    private int durationDays;
+
+    public static RestockNotificationRequestDto from(RestockNotificationRequestVo vo) {
+        return RestockNotificationRequestDto.builder()
+                .productOptionId(vo.getProductOptionId())
+                .durationDays(vo.getDurationDays())
+                .build();
+    }
+}

--- a/src/main/java/com/example/shinsekai/notification/entity/RestockNotification.java
+++ b/src/main/java/com/example/shinsekai/notification/entity/RestockNotification.java
@@ -1,0 +1,59 @@
+package com.example.shinsekai.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(
+        name = "restock_notification",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"memberUuid", "productOptionId"})
+        }
+)
+public class RestockNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String memberUuid;
+
+    @Column(nullable = false, unique = true)
+    private Long productOptionId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime validUntil;
+
+    @Column(nullable = false)
+    private boolean notified = false;
+
+    @Column
+    private LocalDateTime notifiedAt;
+
+    @Builder
+    public RestockNotification(
+            String memberUuid,
+            Long productOptionId,
+            LocalDateTime requestedAt,
+            LocalDateTime validUntil) {
+        this.memberUuid = memberUuid;
+        this.productOptionId = productOptionId;
+        this.requestedAt = requestedAt;
+        this.validUntil = validUntil;
+    }
+
+    public void markAsNotified() {
+        this.notified = true;
+        this.notifiedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/shinsekai/notification/infrastructure/RestockNotificationRepository.java
+++ b/src/main/java/com/example/shinsekai/notification/infrastructure/RestockNotificationRepository.java
@@ -1,0 +1,19 @@
+package com.example.shinsekai.notification.infrastructure;
+
+import com.example.shinsekai.notification.entity.RestockNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface RestockNotificationRepository extends JpaRepository<RestockNotification, Long> {
+
+    boolean existsByMemberUuidAndProductOptionIdAndNotifiedFalse(String memberUuid, Long productOptionId);
+
+    List<RestockNotification> findAllByProductOptionIdAndNotifiedFalseAndValidUntilAfter(
+            Long productOptionId,
+            LocalDateTime now
+    );
+}

--- a/src/main/java/com/example/shinsekai/notification/presentation/RestockNotificationController.java
+++ b/src/main/java/com/example/shinsekai/notification/presentation/RestockNotificationController.java
@@ -1,0 +1,31 @@
+package com.example.shinsekai.notification.presentation;
+
+import com.example.shinsekai.common.entity.BaseResponseEntity;
+import com.example.shinsekai.common.entity.BaseResponseStatus;
+import com.example.shinsekai.common.jwt.JwtTokenProvider;
+import com.example.shinsekai.notification.application.RestockNotificationService;
+import com.example.shinsekai.notification.dto.in.RestockNotificationRequestDto;
+import com.example.shinsekai.notification.vo.in.RestockNotificationRequestVo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Restock", description = "재입고 알림 API")
+@RestController
+@RequestMapping("/api/v1/restock")
+@RequiredArgsConstructor
+public class RestockNotificationController {
+
+    private final RestockNotificationService restockNotificationService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "재입고 알림 신청")
+    @PostMapping("/notify")
+    public BaseResponseEntity<Void> requestRestock(HttpServletRequest request, @RequestBody RestockNotificationRequestVo vo){
+        String memberUuid = jwtTokenProvider.getAccessToken(request);
+        restockNotificationService.register(memberUuid, RestockNotificationRequestDto.from(vo));
+        return new BaseResponseEntity<>(BaseResponseStatus.SUCCESS);
+    }
+}

--- a/src/main/java/com/example/shinsekai/notification/vo/in/RestockNotificationRequestVo.java
+++ b/src/main/java/com/example/shinsekai/notification/vo/in/RestockNotificationRequestVo.java
@@ -1,0 +1,9 @@
+package com.example.shinsekai.notification.vo.in;
+
+import lombok.Getter;
+
+@Getter
+public class RestockNotificationRequestVo {
+    private Long productOptionId;
+    private int durationDays;
+}


### PR DESCRIPTION
# 🚀 Pull Request 

## 🔗 관련 이슈
`Resolves #92 `

## ✨ 변경 사항
- 이메일 전송 API에 재입고 알림까지 추가
- 품절인 상품에 재입고 알림 신청 가능
- 품절인 상품이 재고가 증가 할 경우 알림 신청한 유저에게 메일 전송

## 📸스크린샷 (옵션)
![image](https://github.com/user-attachments/assets/72f6dbc6-dbb3-4bc6-92a0-a9b55e631dae)

