### PR TITLE
Fix: Cart option값이 null인 경우 처리

### DIFF
--- a/src/main/java/com/example/shinsekai/cart/entity/Cart.java
+++ b/src/main/java/com/example/shinsekai/cart/entity/Cart.java
@@ -24,7 +24,7 @@ public class Cart extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String memberUuid;
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private Long productOptionListId;
 
     @Column(nullable = false, length = 50)


### PR DESCRIPTION

# 🚀 Pull Request 

## 🔗 관련 이슈
- Resolves #9

## ✨ 변경 사항
- Cart의 productOptionListId값이 null인 경우도 처리하도록 구현
- 상품별에서 옵션별 구매갯수 제한으로 변경

## 📸스크린샷 (옵션)
