### PR TITLE
Feat: Event 썸네일 추가 및 조회 구현

### DIFF
--- a/src/main/java/com/example/shinsekai/event/application/EventService.java
+++ b/src/main/java/com/example/shinsekai/event/application/EventService.java
@@ -3,7 +3,9 @@ package com.example.shinsekai.event.application;
 import com.example.shinsekai.event.dto.in.EventCreateRequestDto;
 import com.example.shinsekai.event.dto.in.EventUpdateRequestDto;
 import com.example.shinsekai.event.dto.out.EventGetDetailResponseDto;
+import com.example.shinsekai.event.dto.out.EventGetThumbnailResponseDto;
 import com.example.shinsekai.event.dto.out.EventGetTitleResponseDto;
+import com.example.shinsekai.event.vo.in.EventGetThumbnailResponseVo;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,4 +16,5 @@ public interface EventService {
     List<EventGetTitleResponseDto> getAllEventTitle();
     void updateEvent(EventUpdateRequestDto eventUpdateRequestDto);
     void deleteEvent(Integer eventId);
+    List<EventGetThumbnailResponseDto> getAllEventThumbnail();
 }

--- a/src/main/java/com/example/shinsekai/event/application/EventServiceImpl.java
+++ b/src/main/java/com/example/shinsekai/event/application/EventServiceImpl.java
@@ -5,12 +5,15 @@ import com.example.shinsekai.common.exception.BaseException;
 import com.example.shinsekai.event.dto.in.EventCreateRequestDto;
 import com.example.shinsekai.event.dto.in.EventUpdateRequestDto;
 import com.example.shinsekai.event.dto.out.EventGetDetailResponseDto;
+import com.example.shinsekai.event.dto.out.EventGetThumbnailResponseDto;
 import com.example.shinsekai.event.dto.out.EventGetTitleResponseDto;
 import com.example.shinsekai.event.entity.Event;
 import com.example.shinsekai.event.infrastructure.EventRepository;
 import com.example.shinsekai.season.dto.out.SeasonGetResponseDto;
 import com.example.shinsekai.season.entity.Season;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -29,15 +32,23 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventGetDetailResponseDto getEventDetail(Integer eventId) {
-        return EventGetDetailResponseDto.from(eventRepository.findById(eventId)
+        return EventGetDetailResponseDto.from(eventRepository.findOngoingEventById(eventId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_EVENT)));
     }
 
     @Override
     public List<EventGetTitleResponseDto> getAllEventTitle() {
-        return eventRepository.findAll(Sort.by(Sort.Order.desc("startDate")))
+        return eventRepository.findAllOngoingEvents(Pageable.unpaged())
                 .stream()
                 .map(EventGetTitleResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    public List<EventGetThumbnailResponseDto> getAllEventThumbnail() {
+        return eventRepository.findAllOngoingEvents(PageRequest.of(0, 6))
+                .stream()
+                .map(EventGetThumbnailResponseDto::from)
                 .toList();
     }
 

--- a/src/main/java/com/example/shinsekai/event/dto/in/EventCreateRequestDto.java
+++ b/src/main/java/com/example/shinsekai/event/dto/in/EventCreateRequestDto.java
@@ -12,15 +12,20 @@ public class EventCreateRequestDto {
     private String eventName;
     private String eventImage;
     private String eventImageAltText;
+    private String eventThumbnailImage;
+    private String eventThumbnailImageAltText;
     private LocalDate startDate;
     private LocalDate endDate;
 
     @Builder
     public EventCreateRequestDto(String eventName, String eventImage, String eventImageAltText,
+                                 String eventThumbnailImage, String eventThumbnailImageAltText,
                                  LocalDate startDate, LocalDate endDate) {
         this.eventName = eventName;
         this.eventImage = eventImage;
         this.eventImageAltText = eventImageAltText;
+        this.eventThumbnailImage = eventThumbnailImage;
+        this.eventThumbnailImageAltText = eventThumbnailImageAltText;
         this.startDate = startDate;
         this.endDate = endDate;
     }
@@ -30,6 +35,8 @@ public class EventCreateRequestDto {
                 .eventName(vo.getEventName())
                 .eventImage(vo.getEventImage())
                 .eventImageAltText(vo.getEventImageAltText())
+                .eventThumbnailImage(vo.getEventThumbnailImage())
+                .eventThumbnailImageAltText(vo.getEventThumbnailImageAltText())
                 .startDate(vo.getStartDate())
                 .endDate(vo.getEndDate())
                 .build();
@@ -40,6 +47,8 @@ public class EventCreateRequestDto {
                 .eventName(eventName)
                 .eventImage(eventImage)
                 .eventImageAltText(eventImageAltText)
+                .eventThumbnailImage(eventThumbnailImage)
+                .eventThumbnailImageAltText(eventThumbnailImageAltText)
                 .startDate(startDate)
                 .endDate(endDate)
                 .build();

--- a/src/main/java/com/example/shinsekai/event/dto/out/EventGetThumbnailResponseDto.java
+++ b/src/main/java/com/example/shinsekai/event/dto/out/EventGetThumbnailResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.shinsekai.event.dto.out;
+
+import com.example.shinsekai.event.entity.Event;
+import com.example.shinsekai.event.vo.in.EventGetThumbnailResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EventGetThumbnailResponseDto {
+    private Integer id;
+    private String eventThumbnailImage;
+    private String eventThumbnailImageAltText;
+
+    @Builder
+    public EventGetThumbnailResponseDto(Integer id, String eventThumbnailImage, String eventThumbnailImageAltText) {
+        this.id = id;
+        this.eventThumbnailImage = eventThumbnailImage;
+        this.eventThumbnailImageAltText = eventThumbnailImageAltText;
+    }
+
+    public EventGetThumbnailResponseVo toVo(){
+        return EventGetThumbnailResponseVo.builder()
+                .id(id)
+                .eventThumbnailImage(eventThumbnailImage)
+                .eventThumbnailImageAltText(eventThumbnailImageAltText)
+                .build();
+    }
+
+    public static EventGetThumbnailResponseDto from(Event event) {
+        return EventGetThumbnailResponseDto.builder()
+                .id(event.getId())
+                .eventThumbnailImage(event.getEventThumbnailImage())
+                .eventThumbnailImageAltText(event.getEventThumbnailImageAltText())
+                .build();
+    }
+}

--- a/src/main/java/com/example/shinsekai/event/entity/Event.java
+++ b/src/main/java/com/example/shinsekai/event/entity/Event.java
@@ -27,6 +27,13 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private String eventImageAltText;
 
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String eventThumbnailImage;
+
+    @Column(nullable = false)
+    private String eventThumbnailImageAltText;
+
     @Column(nullable = false)
     private LocalDate startDate;
 
@@ -34,12 +41,14 @@ public class Event extends BaseEntity {
     private LocalDate endDate;
 
     @Builder
-    public Event(int id, String eventName, String eventImage, String eventImageAltText,
-                 LocalDate startDate, LocalDate endDate) {
+    public Event(int id, String eventName, String eventImage, String eventImageAltText, String eventThumbnailImage,
+                 String eventThumbnailImageAltText, LocalDate startDate, LocalDate endDate) {
         this.id = id;
         this.eventName = eventName;
         this.eventImage = eventImage;
         this.eventImageAltText = eventImageAltText;
+        this.eventThumbnailImage = eventThumbnailImage;
+        this.eventThumbnailImageAltText = eventThumbnailImageAltText;
         this.startDate = startDate;
         this.endDate = endDate;
     }

--- a/src/main/java/com/example/shinsekai/event/infrastructure/EventRepository.java
+++ b/src/main/java/com/example/shinsekai/event/infrastructure/EventRepository.java
@@ -1,7 +1,20 @@
 package com.example.shinsekai.event.infrastructure;
 
 import com.example.shinsekai.event.entity.Event;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Integer> {
+    @Query("SELECT e FROM Event e WHERE e.id = :id AND CURRENT_DATE BETWEEN e.startDate AND e.endDate")
+    Optional<Event> findOngoingEventById(@Param("id") Integer id);
+
+    @Query("SELECT e FROM Event e WHERE CURRENT_DATE BETWEEN e.startDate AND e.endDate ORDER BY e.startDate DESC")
+    List<Event> findAllOngoingEvents(Pageable pageable);
 }

--- a/src/main/java/com/example/shinsekai/event/presentation/EventController.java
+++ b/src/main/java/com/example/shinsekai/event/presentation/EventController.java
@@ -5,8 +5,10 @@ import com.example.shinsekai.common.entity.BaseResponseStatus;
 import com.example.shinsekai.event.application.EventServiceImpl;
 import com.example.shinsekai.event.dto.in.EventCreateRequestDto;
 import com.example.shinsekai.event.dto.in.EventUpdateRequestDto;
+import com.example.shinsekai.event.dto.out.EventGetThumbnailResponseDto;
 import com.example.shinsekai.event.dto.out.EventGetTitleResponseDto;
 import com.example.shinsekai.event.vo.in.EventCreateRequestVo;
+import com.example.shinsekai.event.vo.in.EventGetThumbnailResponseVo;
 import com.example.shinsekai.event.vo.in.EventUpdateRequestVo;
 import com.example.shinsekai.event.vo.out.EventGetDetailResponseVo;
 import com.example.shinsekai.event.vo.out.EventGetTitleResponseVo;
@@ -43,6 +45,13 @@ public class EventController {
     public BaseResponseEntity<List<EventGetTitleResponseVo>> getAllEventTitle() {
         return new BaseResponseEntity<>(eventService.getAllEventTitle().stream()
                 .map(EventGetTitleResponseDto::toVo).toList());
+    }
+
+    @Operation(summary = "기획전 썸네일 리스트 조회")
+    @GetMapping("/thumbnail")
+    public BaseResponseEntity<List<EventGetThumbnailResponseVo>> getAllEventThumbnail() {
+        return new BaseResponseEntity<>(eventService.getAllEventThumbnail().stream()
+                .map(EventGetThumbnailResponseDto::toVo).toList());
     }
 
     @Operation(summary = "기획전 수정")

--- a/src/main/java/com/example/shinsekai/event/vo/in/EventCreateRequestVo.java
+++ b/src/main/java/com/example/shinsekai/event/vo/in/EventCreateRequestVo.java
@@ -12,15 +12,20 @@ public class EventCreateRequestVo {
     private String eventName;
     private String eventImage;
     private String eventImageAltText;
+    private String eventThumbnailImage;
+    private String eventThumbnailImageAltText;
     private LocalDate startDate;
     private LocalDate endDate;
 
     @Builder
     public EventCreateRequestVo(String eventName, String eventImage, String eventImageAltText,
+                                String eventThumbnailImage, String eventThumbnailImageAltText,
                                 LocalDate startDate, LocalDate endDate) {
         this.eventName = eventName;
         this.eventImage = eventImage;
         this.eventImageAltText = eventImageAltText;
+        this.eventThumbnailImage = eventThumbnailImage;
+        this.eventThumbnailImageAltText = eventThumbnailImageAltText;
         this.startDate = startDate;
         this.endDate = endDate;
     }

--- a/src/main/java/com/example/shinsekai/event/vo/in/EventGetThumbnailResponseVo.java
+++ b/src/main/java/com/example/shinsekai/event/vo/in/EventGetThumbnailResponseVo.java
@@ -1,0 +1,18 @@
+package com.example.shinsekai.event.vo.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EventGetThumbnailResponseVo {
+    private Integer id;
+    private String eventThumbnailImage;
+    private String eventThumbnailImageAltText;
+
+    @Builder
+    public EventGetThumbnailResponseVo(Integer id, String eventThumbnailImage, String eventThumbnailImageAltText) {
+        this.id = id;
+        this.eventThumbnailImage = eventThumbnailImage;
+        this.eventThumbnailImageAltText = eventThumbnailImageAltText;
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request 

## 🔗 관련 이슈
- Resolves #88

## ✨ 변경 사항
- Event 썸네일 이미지 관련 필드 추가
- 썸네일 이미지 조회 API 구현
- 진행중인 event만 조회하도록 jpa 쿼리 수정

## 📸스크린샷 (옵션)